### PR TITLE
[FEATURE][PART] MET-35: enable cli installation via homebrew

### DIFF
--- a/Formula/onmetal.rb
+++ b/Formula/onmetal.rb
@@ -1,0 +1,17 @@
+class Onmetal < Formula
+  desc "The missing PaaS for Hetzner"
+  homepage "https://github.com/onmetal-dev/metal"
+  version "0.0.1"
+
+  on_macos do
+    if Hardware::CPU.intel?
+      url "https://github.com/onmetal-dev/metal/releases/download/v0.0.1/onmetal-0.0.1-alpha-macos-x64.tar.gz"
+      sha256 "foo-bar"
+
+      # bun build --compile --target=bun --outfile onmetal apps/cli/src/index.ts
+      def install
+        bin.install "onmetal"
+      end
+    end
+  end
+end

--- a/Formula/onmetal.rb
+++ b/Formula/onmetal.rb
@@ -5,10 +5,9 @@ class Onmetal < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/onmetal-dev/metal/releases/download/v0.0.1/onmetal-0.0.1-alpha-macos-x64.tar.gz"
-      sha256 "foo-bar"
+      url "https://github.com/onmetal-dev/metal/releases/download/v0.0.1-alpha-5/onmetal-macos-x64.tar.gz"
+      sha256 "204d8a061316f6251f7eadb0f46e62f806f68e8d349efed8c5c52c11b92db1b9"
 
-      # bun build --compile --target=bun --outfile onmetal apps/cli/src/index.ts
       def install
         bin.install "onmetal"
       end

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# homebrew-cli
-A Hombrew tap that supplies formulae for installing Metal's CLI.
+# homebrew-metal
+A Hombrew tap that supplies formulae for installing Metal's CLI and others.
+
+# Installation
+brew tap onmetal-dev/homebrew-cli
+brew install onmetal


### PR DESCRIPTION
This is part 1 of enabling the installation of Metal's CLI via homebrew.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e265749563d70a0799fc52ba5f211886a5bea914  | 
|--------|--------|

### Summary:
Add Homebrew formula for Metal CLI and update README with installation instructions.

**Key points**:
- Added `Formula/onmetal.rb` to define a Homebrew formula for Metal CLI.
- Formula supports macOS with Intel CPUs.
- Updated `README.md` with installation instructions.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->